### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,14 @@ print(generated_nif)
 
 You will obtain the NIF representation as a string:
 ```turtle
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix nif: <http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#> .
+@prefix itsrdf: <http://www.w3.org/2005/11/its/rdf#> .
+@prefix dcterms: <http://purl.org/dc/terms/>
+
 <http://freme-project.eu> a nif:ContextCollection ;
     nif:hasContext <http://freme-project.eu/doc32> ;
-    ns1:conformsTo <http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core/2.1> .
+    dcterms:conformsTo <http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core/2.1> .
 
 <http://freme-project.eu/doc32> a nif:Context,
         nif:OffsetBasedString ;
@@ -109,6 +114,7 @@ You will obtain the NIF representation as a string:
         <http://dbpedia.org/ontology/PopulatedPlace>,
         <http://nerd.eurecom.fr/ontology#Location> ;
     itsrdf:taConfidence 9.804964e-01 .
+    
 ```
 
 4) You can then parse it back:


### PR DESCRIPTION
> Added missing prefix declarations and changed ns1 to dcterms.
> This is necessary to parse the example outside pynif. Not sure if pynif itself can parse it the way it was. Also, pynif should probably be changed to write these prefixes out.